### PR TITLE
Fix to readJunctionSeqCounts() countdata handling

### DIFF
--- a/JunctionSeq/R/func.R
+++ b/JunctionSeq/R/func.R
@@ -608,7 +608,7 @@ readJunctionSeqCounts <- function(countfiles = NULL, countdata = NULL,
      lf <- countdata
    }
    
-   if( !all( sapply( lf[-1], function(x) all( x$V1 == lf[1]$V1 ) ) ) )
+   if( !all( sapply( lf[-1], function(x) all( x$V1 == lf[[1]]$V1 ) ) ) )
       stop( "Count files have differing gene ID column." )
    if(isTRUE(verbose)) message("---> File read complete.");  
 


### PR DESCRIPTION
Formal `countdata` is expected to be a list of data.frames which is passed to `lf` in line 608. In line 611, the code segment `x$V1 == lf[1]$V1` attempted to confirm that the order of all feature ids was the same in the current and first input data.frames. However, `lf[1]` returns a list containing 1 data.frame instead of the data.frame itself, so `lf[1]$V1` returns `NULL` and throws the following warning:

```
> if (!all(sapply(lf[-1], function(x) all(x$V1 == lf[1]$V1)))) 
+     stop("Count files have differing gene ID column.")
Warning message:
In is.na(e2) : is.na() applied to non-(list or vector) of type 'NULL'
```